### PR TITLE
Use inbound-agent for test

### DIFF
--- a/src/test/java/net/sghill/testcontainers/jenkins/JenkinsContainerTest.java
+++ b/src/test/java/net/sghill/testcontainers/jenkins/JenkinsContainerTest.java
@@ -104,7 +104,7 @@ public class JenkinsContainerTest {
                     AgentResponse.create("agent-1", true, false)
             ));
 
-            try (GenericContainer<?> agent = new GenericContainer<>(DockerImageName.parse("jenkins/jnlp-agent-jdk11"))) {
+            try (GenericContainer<?> agent = new GenericContainer<>(DockerImageName.parse("jenkins/inbound-agent"))) {
                 agent
                         .withNetwork(network)
                         .withCommand("-direct", "jcontroller:50000", "-instanceIdentity", instanceIdentity, "-workDir", "/workspace", genAgent.secret(), genAgent.name())


### PR DESCRIPTION
Tests started failing (only on Actions) because the agent is running an older jdk than the controller. Will see if dropping the jdk improves the tests.

```
[Test worker] ERROR tc.jenkins/jnlp-agent-jdk11:latest - Log output from the failed container:
Error: LinkageError occurred while loading main class hudson.remoting.Launcher
	java.lang.UnsupportedClassVersionError: hudson/remoting/Launcher has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```